### PR TITLE
fix: change 'profiles' to 'users'

### DIFF
--- a/src/lib/server-actions/auth-actions.ts
+++ b/src/lib/server-actions/auth-actions.ts
@@ -23,7 +23,7 @@ export async function actionSignUpUser({
 }: z.infer<typeof FormSchema>) {
   const supabase = createRouteHandlerClient({ cookies });
   const { data } = await supabase
-    .from('profiles')
+    .from('users')
     .select('*')
     .eq('email', email);
 


### PR DESCRIPTION
The schema file in the migrations folder uses 'users' as a table name not 'profiles'.